### PR TITLE
Use find -exec syntax for chown/chgrp for long names

### DIFF
--- a/shell/run-dev.sh
+++ b/shell/run-dev.sh
@@ -20,13 +20,11 @@ fi
 . $SANDSTORM_HOME/sandstorm.conf
 
 if [ "$SERVER_USER" != "$USER" ]; then
-  echo "Please change your Sandstorm installation to be own by your own user" >&2
+  echo "Please change your Sandstorm installation to be owned by your own user" >&2
   echo "account. E.g. run as root:" >&2
   echo "  $SANDSTORM_HOME/sandstorm stop" >&2
-  echo "  find $SANDSTORM_HOME/var -user $SERVER_USER -print0 | \\" >&2
-  echo "      xargs -0 chown -h $USER" >&2
-  echo "  find $SANDSTORM_HOME/var -group $(id -gn $SERVER_USER) -print0 | \\" >&2
-  echo "      xargs -0 chgrp -h $(id -gn)" >&2
+  echo "  find $SANDSTORM_HOME/var -user $SERVER_USER -exec chown -h $USER {} \;" >&2
+  echo "  find $SANDSTORM_HOME/var -group $(id -gn $SERVER_USER) -exec chgrp -h $USER {} \;" >&2
   echo "  sed -i -e 's/^SERVER_USER=.*$/SERVER_USER=$USER/g' \\" >&2
   echo "      $SANDSTORM_HOME/sandstorm.conf" >&2
   echo "  $SANDSTORM_HOME/sandstorm start" >&2


### PR DESCRIPTION
When executing the xargs version on my machine, the number and length of files exceeded the allowed size and failed. The -exec worked, however.
